### PR TITLE
mmuldo fixes

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -2,8 +2,8 @@
 - hosts: 127.0.0.1
   connection: local
   vars:
-    - local_user: "han"
-    - github_user: "patrick-motard"
+    - local_user: "matt"
+    - github_user: "mmuldo"
     - new_install: true
     - background_images_dir: "{{ansible_user_dir}}/Dropbox/photos/backgrounds/2017/selected"
     - dot_ansible_path: "{{ansible_user_dir}}/code/dot-ansible"

--- a/main.yml
+++ b/main.yml
@@ -1,9 +1,14 @@
 ---
 - hosts: 127.0.0.1
   connection: local
+  vars_prompt:
+    - name: local_user
+      prompt: "local user"
+      private: no
+    - name: github_user
+      prompt: "github user"
+      private: no
   vars:
-    - local_user: "matt"
-    - github_user: "mmuldo"
     - new_install: true
     - background_images_dir: "{{ansible_user_dir}}/Dropbox/photos/backgrounds/2017/selected"
     - dot_ansible_path: "{{ansible_user_dir}}/code/dot-ansible"

--- a/roles/lastpass/tasks/main.yml
+++ b/roles/lastpass/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Install dependencies
+  become: true
   pacman:
     name: lastpass-cli
     state: present

--- a/roles/pacman/files/pacman-pkgs-core
+++ b/roles/pacman/files/pacman-pkgs-core
@@ -36,7 +36,6 @@ facter
 xf86-video-vesa
 nvidia
 nvidia-utils
-lib32-nvidia-utils
 scrot
 gtop
 ncurses

--- a/thumbnails.yml
+++ b/thumbnails.yml
@@ -1,6 +1,7 @@
 ---
 # This file includes all the tasks needed to enable thumbnails in Thunar (the file explorer/manager) for images and videos.
 - name: Install required packages.
+  become: true
   pacman:
     name: [
     'tumbler',


### PR DESCRIPTION
* removes lib32-nvidia-utils package (no longer exists)
* adds missing `become` statements
* prompts for local user and github user instead of hard-coding